### PR TITLE
fix(perf): connection pooling and pexec

### DIFF
--- a/sample_client_api/bootup/nvidia_objects.py
+++ b/sample_client_api/bootup/nvidia_objects.py
@@ -30,10 +30,12 @@ def initialize_nvidia_service() -> NvidiaImageGenerationTaskHandler:
 class BootupManager:
     def __init__(self):
         self.nvidia_task_handler: NvidiaImageGenerationTaskHandler = None
-        self.perform_bootup()
 
     def perform_bootup(self):
         self.nvidia_task_handler = initialize_nvidia_service()
+
+    async def perform_shutdown(self):
+        await self.nvidia_task_handler.close()
 
 
 IMMUTABLE_BOOTUP_MANAGER = BootupManager()

--- a/sample_client_api/fastapi.py
+++ b/sample_client_api/fastapi.py
@@ -34,6 +34,8 @@ def get_basic_fastapi_app() -> FastAPI:
     fast_app = FastAPI(**opts)
     logger.info("FastAPI is up and running ...")
     log_environment_configs()
+    fast_app.add_event_handler(event_type="shutdown",
+                               func=IMMUTABLE_BOOTUP_MANAGER.perform_shutdown)
     return fast_app
 
 

--- a/sample_client_api/nvidia/nvidia_task_handler.py
+++ b/sample_client_api/nvidia/nvidia_task_handler.py
@@ -23,6 +23,9 @@ class NvidiaImageGenerationTaskHandler:
     def __init__(self, nvcf_url: str, auth_config: NvidiaAuthConfig):
         self.nvidia_client = NvidiaImageGenerationClient(nvcf_url, auth_config)
 
+    async def close(self):
+        await self.nvidia_client.close()
+
     async def handle_nvidia_task(
         self,
         nvidia_client_request: NvidiaRequest,


### PR DESCRIPTION
pooling connections across the application prevents the need to re-establish a TLS session to NVCF for every incoming request

pexec will return the raw response body of a function